### PR TITLE
refactor: Use InjectionToken for Configuration

### DIFF
--- a/projects/filestack-angular/src/lib/filestack.module.ts
+++ b/projects/filestack-angular/src/lib/filestack.module.ts
@@ -1,45 +1,43 @@
-import { CommonModule } from '@angular/common';
-import { NgModule, ModuleWithProviders } from '@angular/core';
-import { FilestackService } from './filestack.service';
-import { FilestackTransformPipe } from './filestack-transform.pipe';
-import { PickerOverlayComponent } from './picker/pickerOverlay.component';
-import { PickerInlineComponent } from './picker/pickerInline.component';
-import { PickerDropPaneComponent } from './picker/pickerDropPane.component';
-import { ClientOptions } from 'filestack-js';
+import { CommonModule } from "@angular/common";
+import { NgModule, ModuleWithProviders } from "@angular/core";
+import { FilestackService } from "./filestack.service";
+import { FilestackTransformPipe } from "./filestack-transform.pipe";
+import { PickerOverlayComponent } from "./picker/pickerOverlay.component";
+import { PickerInlineComponent } from "./picker/pickerInline.component";
+import { PickerDropPaneComponent } from "./picker/pickerDropPane.component";
+import { ClientOptions } from "filestack-js";
 
 export type InitialConfig = {
-  apikey?: string,
-  options?: ClientOptions
-}
+  apikey?: string;
+  options?: ClientOptions;
+};
 
+export const FILSTACK_CONFIG = new InjectionToken<InitialConfig>("config");
 
 @NgModule({
-  imports: [
-    CommonModule,
-  ],
-  providers: [
-    FilestackService
-  ],
+  imports: [CommonModule],
+  providers: [FilestackService],
   declarations: [
     PickerOverlayComponent,
     PickerInlineComponent,
     PickerDropPaneComponent,
-    FilestackTransformPipe
+    FilestackTransformPipe,
   ],
   exports: [
     PickerOverlayComponent,
     PickerInlineComponent,
     PickerDropPaneComponent,
-    FilestackTransformPipe
-  ]
+    FilestackTransformPipe,
+  ],
 })
 export class FilestackModule {
-
   static forRoot(config: InitialConfig): ModuleWithProviders<FilestackModule> {
-
     return {
       ngModule: FilestackModule,
-      providers: [FilestackService, { provide: 'config', useValue: config }]
+      providers: [
+        FilestackService,
+        { provide: FILSTACK_CONFIG, useValue: config },
+      ],
     };
   }
 }

--- a/projects/filestack-angular/src/lib/filestack.service.ts
+++ b/projects/filestack-angular/src/lib/filestack.service.ts
@@ -1,6 +1,6 @@
-import { InitialConfig } from './filestack.module';
-import { Injectable, Inject, Optional } from '@angular/core';
-import { from, Observable } from 'rxjs';
+import { FILSTACK_CONFIG, InitialConfig } from "./filestack.module";
+import { Injectable, Inject, Optional } from "@angular/core";
+import { from, Observable } from "rxjs";
 import {
   PickerOptions,
   PickerInstance,
@@ -16,19 +16,19 @@ import {
   ClientOptions,
   Client,
   init,
-} from 'filestack-js';
-
+} from "filestack-js";
 
 @Injectable()
 export class FilestackService {
-
   private clientInstance: Client;
 
   private clientOptions: ClientOptions;
 
   private apikey: string;
 
-  constructor(@Optional() @Inject('config') private config?: InitialConfig) {
+  constructor(
+    @Optional() @Inject(FILSTACK_CONFIG) private config?: InitialConfig
+  ) {
     if (!config) {
       return;
     }
@@ -65,7 +65,10 @@ export class FilestackService {
    * @param clientOptions - Client options
    */
   init(apikey?: string, clientOptions?: ClientOptions): Client {
-    this.client = init(apikey || this.apikey, clientOptions || this.clientOptions);
+    this.client = init(
+      apikey || this.apikey,
+      clientOptions || this.clientOptions
+    );
 
     return this.client;
   }
@@ -152,10 +155,14 @@ export class FilestackService {
     security?: Security
   ): Observable<object> {
     if (Array.isArray(file)) {
-      return from(this.client.multiupload(file, options, storeOptions, token, security));
+      return from(
+        this.client.multiupload(file, options, storeOptions, token, security)
+      );
     }
 
-    return from(this.client.upload(file, options, storeOptions, token, security));
+    return from(
+      this.client.upload(file, options, storeOptions, token, security)
+    );
   }
 
   /**


### PR DESCRIPTION
Use an InjectionToken instead of a string token for configuration.

## Changes

### Key Changes
	•	Added InjectionToken: Introduced FILESTACK_CONFIG token for strongly-typed configuration injection
	•	Updated Module: FilestackModule now uses the InjectionToken instead of a string token
	•	Updated Service: FilestackService now injects configuration via InjectionToken

## Benefits

### Typing
	•	Better Typing: InjectionToken ensures strict typing of the configuration
	•	Type Safety: Prevents errors when using incorrect tokens

### Security
	•	Unique Tokens: InjectionToken guarantees uniqueness within the application
	•	Conflict Prevention: Eliminates potential token name conflicts